### PR TITLE
models classをCmsCoreのファイルを継承して使うように変更

### DIFF
--- a/app/Helpers/DynamicContentHelper.php
+++ b/app/Helpers/DynamicContentHelper.php
@@ -12,9 +12,6 @@
 function firstPartsByCmsDefinedKey($contents, $cmsDefinedKey)
 {
     $result = null;
-    if (is_string($contents)) {
-        $contents = json_decode($contents);
-    }
 
     foreach ($contents->dynamic as $dynamic) {
         if(property_exists($dynamic, $cmsDefinedKey)){

--- a/app/Http/Controllers/DepartmentController.php
+++ b/app/Http/Controllers/DepartmentController.php
@@ -12,8 +12,7 @@ class DepartmentController extends Controller
         $departmentArticles = Article::getArticlesByArticleType(Article::CHANNEL_ARTICLE_TYPE)
             ->get()
             ->sortBy(function($departmentArticle) {
-                $contents = json_decode($departmentArticle->contents);
-                return $contents->department_sortnumber;
+                return $departmentArticle->contents->department_sortnumber;
             });
 
         $departmentListArticle = Article::getArticlesByArticleType(Article::DEPARTMENT_LIST_ARTICLE_TYPE)->first();

--- a/app/Http/Controllers/Guide/FacilityController.php
+++ b/app/Http/Controllers/Guide/FacilityController.php
@@ -17,17 +17,18 @@ class FacilityController extends Controller
         if (is_null($facilityArticle)) abort(404,"[FacilityController] facility article slug: $permalink not exists in DB.");
 
         // 施設詳細の記事取得
-        $getFacilityList = json_decode($facilityArticle->contents)->get_facility_list;
+        // TODO: 件数取得ロジックを改めて改修する
+        // $getFacilityList = $facilityArticle->contents->get_facility_list;
         $facilityDetailArticles = Article::getArticlesByArticleType(Article::FACILITY_DETAIL_ARTICLE_TYPE);
-        if(is_null($getFacilityList) || empty($getFacilityList)){
+        // if(is_null($getFacilityList) || empty($getFacilityList)){
             $facilityDetailArticles = $facilityDetailArticles->get();
-        } else {
-            // 取得記事に指定があればそのとおり取得する
-            // TODO: 取得順序をどうするか確認する。
-            $facilityDetailArticles = $facilityDetailArticles
-                ->setArticleIds(explode(config('const.utils.COMMA'), $getFacilityList))
-                ->get();
-        }
+        // } else {
+        //     // 取得記事に指定があればそのとおり取得する
+        //     // TODO: 取得順序をどうするか確認する。
+        //     $facilityDetailArticles = $facilityDetailArticles
+        //         ->setArticleIds(explode(config('const.utils.COMMA'), $getFacilityList))
+        //         ->get();
+        // }
 
         /**
          * 表示サイズと表示数に合わせてfacilityDetailArticlesを分解

--- a/app/Http/Controllers/WhatsNewController.php
+++ b/app/Http/Controllers/WhatsNewController.php
@@ -34,10 +34,9 @@ class WhatsNewController extends Controller
         $infoArticle = Article::findPublishedByPermalinkWithArticleType($key, Article::INFO_ARTICLE_TYPE);
         if (is_null($infoArticle)) abort(404,"[ArticleController] info article slug: $key not exists in DB.");
 
-        $contents = json_decode($infoArticle->contents);
         $infoCategories = Category::getCategoriesBySlug(Category::INFO_PARENT_CATEGORY_SLUG);
-        $infoCategory = $infoCategories->first(function ($infoCategory) use ($contents){
-            return $infoCategory->id == $contents->notice_type[0];
+        $infoCategory = $infoCategories->first(function ($infoCategory) use ($infoArticle){
+            return $infoCategory->id == $infoArticle->contents->notice_type[0];
         });
 
         // 対象記事と同一notice_typeの記事を取得

--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -2,12 +2,10 @@
 
 namespace App\Models;
 
-use Illuminate\Database\Eloquent\Model;
+use App\CmsCore\Models\Article as CmsCoreArticle;
 
-class Article extends Model
+class Article extends CmsCoreArticle
 {
-    protected $table = 'view_articles';
-
     const CHANNEL_ARTICLE_TYPE = 'channel';
     const FACILITY_DETAIL_ARTICLE_TYPE = 'facility_detail';
     const FACILITY_ARTICLE_TYPE = 'facility';
@@ -15,18 +13,6 @@ class Article extends Model
     const TEACHER_ARTICLE_TYPE = 'teacher_detail';
     const DEPARTMENT_LIST_ARTICLE_TYPE = 'department_list';
     const INTRODUCTION_RELATED_PAGE_ARTICLE_TYPE = 'introduction_related_page';
-
-    /**
-     * 日付を変形する属性
-     *
-     * @var array
-     */
-    protected $dates = [
-        'created_at',
-        'updated_at',
-        'publish_at',
-        'expire_at'
-    ];
 
     public static function getArticlesByArticleType($type)
     {
@@ -98,6 +84,7 @@ class Article extends Model
     // ローカルスコープ
 
     // TODO: 記事を表示する条件をグローバルスコープに置き換えたほうが良いか検討する
+    // グローバルスコープにするならCmsCoreの方に移したい
     // 公開中の記事を取得
     public function scopePublishing($query)
     {

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -2,26 +2,12 @@
 
 namespace App\Models;
 
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Collection;
+use App\CmsCore\Models\Category as CmsCoreCategory;
 
-class Category extends Model
+class Category extends CmsCoreCategory
 {
-    protected $table = 'categories';
     const POSITION_PARENT_CATEGORY_SLUG = 'position';
     const DEPARTMENT_PARENT_CATEGORY_SLUG = 'department';
 
     const INFO_PARENT_CATEGORY_SLUG = 'info_category';
-
-    public static function findBySlug($slug)
-    {
-        return Category::where('slug', $slug)->first();
-    }
-
-    public static function getCategoriesBySlug($slug): ?Collection
-    {
-        $slug_item = Category::where('slug', $slug)->first();
-        $category_items = Category::where('parent',$slug_item["id"])->orderBy('display_no','asc')->get();
-        return $category_items;
-    }
 }

--- a/app/Models/SearchArticle/SearchInfoArticle.php
+++ b/app/Models/SearchArticle/SearchInfoArticle.php
@@ -18,6 +18,9 @@ class SearchInfoArticle extends SearchArticle
      */
     public static function getSameNoticeTypeArticleQuery($noticeTypeId = null): Builder
     {
+
+        // TODO: CmsCoreのArticleSearchのメソッドを使ったものに書き換える
+
         $articleIds = [];
         if(!is_null($noticeTypeId)){
             $articleIds = self::getSameNoticeTypeArticleIds($noticeTypeId);

--- a/resources/views/pages/department/index.blade.php
+++ b/resources/views/pages/department/index.blade.php
@@ -13,10 +13,7 @@
             </h2>
             <h2 class="heading-large heading-large--low js-scroll">
                 <div class="heading-large__wrap">
-                    <?php
-                        $contents = json_decode($departmentListArticle->contents);
-                    ?>
-                    <div class="heading-large__text">{{ $contents->headline }}</div>
+                    <div class="heading-large__text">{{ $departmentListArticle->headline }}</div>
                 </div>
             </h2>
         @endif
@@ -24,9 +21,6 @@
             <div class="thumbnail-list thumbnail-list--cols3">
                 <ul class="thumbnail-list__list">
                     @foreach ($departmentArticles as $departmentArticle)
-                        <?php
-                            $contents = json_decode($departmentArticle->contents);
-                        ?>
                         <li class="thumbnail-list__item">
                             <a class="thumbnail-list__inner" href="{{ $departmentArticle->permalink }}">
                                 <div class="thumbnail-list__wrap">
@@ -35,9 +29,9 @@
                                             <?php
                                                 // TODO: サムネイルのダミー画像を指定するように修正する
                                                 $imageSrc = 'http://placehold.jp/254x150.png';
-                                                if (isset($contents->thumbnail_image)) {
+                                                if (isset($departmentArticle->thumbnail_image)) {
                                                     // TODO: サムネイルのサイズに合わせた画像サイズを指定する
-                                                    $imageSrc = imageUrlById($contents->thumbnail_image);
+                                                    $imageSrc = imageUrlById($departmentArticle->thumbnail_image);
                                                 }
                                             ?>
                                             <img class="animation-image-ratio__img" src="{{ $imageSrc }}" alt="">
@@ -47,7 +41,7 @@
                                 <div class="thumbnail-list__title">
                                     <span>{{ $departmentArticle->title }}</span>
                                 </div>
-                                <div class="thumbnail-list__text">{{ $contents->department_description }}</div>
+                                <div class="thumbnail-list__text">{{ $departmentArticle->department_description }}</div>
                             </a>
                         </li>
                     @endforeach
@@ -58,25 +52,22 @@
             <div class="js-scroll animation-slide-in-bottom">
                 <div class="multi-banner">
                     <div class="multi-banner__inner">
-                        <?php
-                            $contents = json_decode($introductionRelatedPageArticle->contents);
-                        ?>
                         <div class="multi-banner__detail">
                             <div class="multi-banner__title">{!! $introductionRelatedPageArticle->title !!}</div>
-                            <div class="multi-banner__text">{{ $contents->body }}</div>
+                            <div class="multi-banner__text">{{ $introductionRelatedPageArticle->body }}</div>
                             <div class="multi-banner__button">
-                                <a class="button-base button-base--yellow" href="{{ $contents->button_url }}">{{ $contents->button_word }}</a>
+                                <a class="button-base button-base--yellow" href="{{ $introductionRelatedPageArticle->button_url }}">{{ $introductionRelatedPageArticle->button_word }}</a>
                             </div>
                         </div>
                         <div class="multi-banner__visual">
                             <div class="multi-banner__image">
                                 <div class="js-scroll animation-image-ratio">
-                                    <img class="animation-image-ratio__img" src="{{ $contents->right_image }}" alt="">
+                                    <img class="animation-image-ratio__img" src="{{ $introductionRelatedPageArticle->right_image }}" alt="">
                                 </div>
                             </div>
                         </div>
                         <div class="multi-banner__sp-button">
-                            <a class="button-base button-base--yellow" href="">{{ $contents->button_word }}</a>
+                            <a class="button-base button-base--yellow" href="">{{ $introductionRelatedPageArticle->button_word }}</a>
                         </div>
                     </div>
                 </div>

--- a/resources/views/pages/teacher/index.blade.php
+++ b/resources/views/pages/teacher/index.blade.php
@@ -31,24 +31,21 @@
             </div>
             @foreach ($positionCategories as $positionCategory)
                 @foreach ($teacherArticles as $teacherArticle)
-                    <?php
-                        $contents = json_decode($teacherArticle->contents);
-                    ?>
-                    @if ($contents->position == $positionCategory->id)
+                    @if ($teacherArticle->position == $positionCategory->id)
                         <h3 class="heading-middle">
                             <div class="heading-middle__text">{{ $positionCategory->name }}</div>
                         </h3>
                         <div class="name-list">
-                            @if ($contents->url)
-                                <div class="name-list__item" data-category="[&quot;{{ implode('&quot;,&quot;', $contents->department) }}&quot;]">
-                                    <a class="name-list__wrap" href="{{ $contents->url }}">
+                            @if ($teacherArticle->url)
+                                <div class="name-list__item" data-category="[&quot;{{ implode('&quot;,&quot;', $teacherArticle->department) }}&quot;]">
+                                    <a class="name-list__wrap" href="{{ $teacherArticle->url }}">
                                         <div class="link-external">
                                             <span class="name-list__text">{{ $teacherArticle->title }}</span>
                                         </div>
                                     </a>
                                 </div>
                             @else
-                                <div class="name-list__item" data-category="[&quot;{{ implode('&quot;,&quot;', $contents->department) }}&quot;]">
+                                <div class="name-list__item" data-category="[&quot;{{ implode('&quot;,&quot;', $teacherArticle->department) }}&quot;]">
                                     <div class="name-list__wrap">
                                         <div class="name-list__text"><span>{{ $teacherArticle->title }}</span></div>
                                     </div>

--- a/resources/views/pages/whats_new/index.blade.php
+++ b/resources/views/pages/whats_new/index.blade.php
@@ -37,9 +37,8 @@
             <ul class="information-list">
                 @foreach ($infoArticles as $infoArticle)
                     <?php
-                        $contents = json_decode($infoArticle->contents);
-                        $infoCategory = $infoCategories->first(function ($infoCategory) use ($contents){
-                            return $infoCategory->id == $contents->notice_type[0];
+                        $infoCategory = $infoCategories->first(function ($infoCategory) use ($infoArticle){
+                            return $infoCategory->id == $infoArticle->notice_type[0];
                         });
                         $infoCategorySlug = $infoCategory ? $infoCategory->slug : 'all';
                         $infoCategoryName = $infoCategory ? $infoCategory->name : 'ALL';
@@ -64,7 +63,7 @@
                             </div>
                             <div class="information-list__image">
                                 <?php
-                                    $noticeImageContents = firstPartsByCmsDefinedKey($contents, 'notice_image');
+                                    $noticeImageContents = firstPartsByCmsDefinedKey($infoArticle->contents, 'notice_image');
                                     // TODO: サムネイルのダミー画像を指定するように修正する
                                     $imageSrc = 'http://placehold.jp/300x200.png';
                                     if (isset($noticeImageContents)) {

--- a/resources/views/pages/whats_new/show.blade.php
+++ b/resources/views/pages/whats_new/show.blade.php
@@ -22,7 +22,6 @@
         </div>
 
         <?php
-        $contents = json_decode($infoArticle->contents);
         // TODO: ここは別の箇所で定数として固めるべきかもしれない。考えておく。
         $dynamicTypeKeys = [
             'single_body',
@@ -33,7 +32,7 @@
         ]
         ?>
         {{-- dynamic parts類表示 --}}
-        @foreach ($contents->dynamic as $dynamic)
+        @foreach ($infoArticle->dynamic as $dynamic)
             @foreach ($dynamicTypeKeys as $dynamicTypeKey)
                 @if (property_exists($dynamic, $dynamicTypeKey ))
                     @includeIf('parts.dynamic.whats_new.' . $dynamicTypeKey, [
@@ -120,7 +119,7 @@
                                     </div>
                                     <div class="side-link-list__image">
                                         <?php
-                                        $noticeImageContents = firstPartsByCmsDefinedKey($contents, 'notice_image');
+                                        $noticeImageContents = firstPartsByCmsDefinedKey($infoArticle->contents, 'notice_image');
                                         // TODO: サムネイルのダミー画像を指定するように修正する
                                         $imageSrc = 'http://placehold.jp/30×30.png';
                                         if (isset($noticeImageContents)) {

--- a/resources/views/partials/dynamic/guide/facility/large_block.blade.php
+++ b/resources/views/partials/dynamic/guide/facility/large_block.blade.php
@@ -6,8 +6,6 @@ if(isset($isExtraLarge) && $isExtraLarge) {
 } else if (isset($isLeft) && $isLeft) {
     $class = 'left';
 }
-
-$contents = json_decode($facilityDetailArticle->contents);
 ?>
 
 <div class="js-scroll animation-slide-in-bottom">
@@ -16,7 +14,7 @@ $contents = json_decode($facilityDetailArticle->contents);
             <picture class="js-scroll animation-image-ratio">
                 <source srcset="/assets/images/_dummy-img01.png" media="(min-width: 768px)">
                 <source srcset="/assets/images/_dummy-img02.png" media="(max-width: 767px)">
-                <img class="visual-block__visual-image animation-image-ratio__img" src="{{ imageUrlById($contents->facility_image) }}" alt="">
+                <img class="visual-block__visual-image animation-image-ratio__img" src="{{ imageUrlById($facilityDetailArticle->facility_image) }}" alt="">
             </picture>
         </div>
         <div class="visual-block__detail">
@@ -25,14 +23,14 @@ $contents = json_decode($facilityDetailArticle->contents);
             </div>
             <div class="visual-block__description">
                 <div class="visual-block__description-title">
-                    {{ $contents->facility_headline }}
+                    {{ $facilityDetailArticle->facility_headline }}
                 </div>
                 <div class="visual-block__description-text">
-                    {{ $contents->facility_description }}
+                    {{ $facilityDetailArticle->facility_description }}
                 </div>
-                @if (!empty($contents->facility_detail_related_url))
+                @if (!empty($facilityDetailArticle->facility_detail_related_url))
                     <div class="visual-block__link">
-                        <a class="link link--arrow" href="{{ route('guide_facility_detail_show', ['permalink' => $contents->facility_detail_related_url]) }}">
+                        <a class="link link--arrow" href="{{ route('guide_facility_detail_show', ['permalink' => $facilityDetailArticle->facility_detail_related_url]) }}">
                             詳細を見る
                         </a>
                     </div>

--- a/resources/views/partials/dynamic/guide/facility/regular_block.blade.php
+++ b/resources/views/partials/dynamic/guide/facility/regular_block.blade.php
@@ -4,14 +4,13 @@ $isDisplaySmall = false;
 if (isset($isSmall) && $isSmall) {
     $isDisplaySmall = true;
 }
-$contents = json_decode($facilityDetailArticle->contents);
 ?>
 
 <div class="visual-block-column__item">
     <div class="visual-block visual-block--gallery{{ $isDisplaySmall ? '--s' : '' }}">
         <div class="visual-block__visual">
             <div class="js-scroll animation-image-ratio">
-                <img class="visual-block__visual-image animation-image-ratio__img" src="{{ imageUrlById($contents->facility_image) }}" alt="">
+                <img class="visual-block__visual-image animation-image-ratio__img" src="{{ imageUrlById($facilityDetailArticle->facility_image) }}" alt="">
             </div>
         </div>
         <div class="visual-block__detail">
@@ -22,14 +21,14 @@ $contents = json_decode($facilityDetailArticle->contents);
             @endif
             <div class="visual-block__description">
                 <div class="visual-block__description-title">
-                    {{ $contents->facility_headline }}
+                    {{ $facilityDetailArticle->facility_headline }}
                 </div>
                 <div class="visual-block__description-text">
-                    {{ $contents->facility_description }}
+                    {{ $facilityDetailArticle->facility_description }}
                 </div>
-                @if (!empty($contents->facility_detail_related_url))
+                @if (!empty($facilityDetailArticle->facility_detail_related_url))
                     <div class="visual-block__link">
-                        <a class="link link--arrow" href="{{ route('guide_facility_detail_show', ['permalink' => $contents->facility_detail_related_url]) }}">
+                        <a class="link link--arrow" href="{{ route('guide_facility_detail_show', ['permalink' => $facilityDetailArticle->facility_detail_related_url]) }}">
                             詳細を見る
                         </a>
                     </div>


### PR DESCRIPTION
## TODO

ArticleObserversを利用することによって
article->contentsが常にjson_decodeされる状態になる。

~~そのため、現状作成しているViewのあらゆるところが **崩壊する**。（エラーまみれ）~~

~~マージ前に十分確認を取ること...~~

cms coreのアップデートに合わせて対応した。

追記：
このあたりはcms coreの修正をやってもらってるので、終わったら崩壊対策する => 対応済み