### PR TITLE
[大阪芸大] サイズごとに設定された記事ID毎にデータを取得する仕様を追加

### DIFF
--- a/app/Http/Controllers/Guide/FacilityController.php
+++ b/app/Http/Controllers/Guide/FacilityController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Guide;
 
 use App\Http\Controllers\Controller;
 use App\Models\Article;
+use App\Models\Article\FacilityDetail;
 
 class FacilityController extends Controller
 {
@@ -16,29 +17,10 @@ class FacilityController extends Controller
         $facilityArticle = Article::findPublishedByPermalinkWithArticleType($permalink, Article::FACILITY_ARTICLE_TYPE);
         if (is_null($facilityArticle)) abort(404,"[FacilityController] facility article slug: $permalink not exists in DB.");
 
-        // 施設詳細の記事取得
-        // TODO: 件数取得ロジックを改めて改修する
-        // $getFacilityList = $facilityArticle->contents->get_facility_list;
-        $facilityDetailArticles = Article::getArticlesByArticleType(Article::FACILITY_DETAIL_ARTICLE_TYPE);
-        // if(is_null($getFacilityList) || empty($getFacilityList)){
-            $facilityDetailArticles = $facilityDetailArticles->get();
-        // } else {
-        //     // 取得記事に指定があればそのとおり取得する
-        //     // TODO: 取得順序をどうするか確認する。
-        //     $facilityDetailArticles = $facilityDetailArticles
-        //         ->setArticleIds(explode(config('const.utils.COMMA'), $getFacilityList))
-        //         ->get();
-        // }
-
-        /**
-         * 表示サイズと表示数に合わせてfacilityDetailArticlesを分解
-         * TODO: 表示数は固定でいいのかは確認する。
-         * HACK: 必要に応じてsliceする処理はmodelクラスに移譲するなど検討する
-         */
-        $displayExtraLargeArticles = $facilityDetailArticles->slice(0, 1);
-        $displayLargeArticles      = $facilityDetailArticles->slice(1, 5);
-        $displayRegularArticles    = $facilityDetailArticles->slice(6, 4);
-        $displaySmallArticles      = $facilityDetailArticles->slice(10, 3);
+        list($displayExtraLargeArticles,
+            $displayLargeArticles,
+            $displayRegularArticles,
+            $displaySmallArticles) = FacilityDetail::getArrayDetailsByFacilityArticle($facilityArticle);
 
         return view('pages/guide/facility/show', compact(
             'facilityArticle',

--- a/app/Models/Article/FacilityDetail.php
+++ b/app/Models/Article/FacilityDetail.php
@@ -22,10 +22,10 @@ class FacilityDetail extends Article
         $xlFacilityIds  = explode(config('consts.utils.COMMA'), $facilityArticle->display_extra_large_facility_ids);
         $lFacilityIds   = explode(config('consts.utils.COMMA'), $facilityArticle->display_large_facility_ids);
         $mFacilityIds   = explode(config('consts.utils.COMMA'), $facilityArticle->display_medium_facility_ids);
-        $sxlFacilityIds = explode(config('consts.utils.COMMA'), $facilityArticle->display_small_facility_ids);
+        $sFacilityIds = explode(config('consts.utils.COMMA'), $facilityArticle->display_small_facility_ids);
 
         // 指定された記事データを取得
-        $facilityDetailArticleIds = array_merge($xlFacilityIds, $lFacilityIds, $mFacilityIds, $sxlFacilityIds);
+        $facilityDetailArticleIds = array_merge($xlFacilityIds, $lFacilityIds, $mFacilityIds, $sFacilityIds);
         $facilityDetailArticles = Article::getArticlesByArticleType(Article::FACILITY_DETAIL_ARTICLE_TYPE)
             ->whereIn('id', $facilityDetailArticleIds)
             ->get();
@@ -35,7 +35,7 @@ class FacilityDetail extends Article
             self::dripDetailArticlesByIds($facilityDetailArticles, $xlFacilityIds),
             self::dripDetailArticlesByIds($facilityDetailArticles, $lFacilityIds),
             self::dripDetailArticlesByIds($facilityDetailArticles, $mFacilityIds),
-            self::dripDetailArticlesByIds($facilityDetailArticles, $sxlFacilityIds),
+            self::dripDetailArticlesByIds($facilityDetailArticles, $sFacilityIds),
         ];
     }
 

--- a/app/Models/Article/FacilityDetail.php
+++ b/app/Models/Article/FacilityDetail.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Models\Article;
+
+use App\Models\Article;
+
+class FacilityDetail extends Article
+{
+    /**
+     * 施設案内の記事から、それぞれ指定の表示サイズに合わせた施設詳細のレコードを取得する
+     * @param Article $facilityArticle
+     * @return array [xl_details, l_details, m_details, s_details]
+     */
+    public static function getArrayDetailsByFacilityArticle(Article $facilityArticle)
+    {
+        // $facilityArticleのarticle_typeが違った場合はエラーとする
+        if ($facilityArticle->article_type !== Article::FACILITY_ARTICLE_TYPE) {
+            abort(500, "[FacilityDetail] getArrayDetailsByFacilityArticle params: facilityArticle->article_type is not FACILITY_ARTICLE_TYPE.");
+        }
+
+        // 表示サイズごとに設定された記事IDを配列として取得
+        $xlFacilityIds  = explode(config('consts.utils.COMMA'), $facilityArticle->display_extra_large_facility_ids);
+        $lFacilityIds   = explode(config('consts.utils.COMMA'), $facilityArticle->display_large_facility_ids);
+        $mFacilityIds   = explode(config('consts.utils.COMMA'), $facilityArticle->display_medium_facility_ids);
+        $sxlFacilityIds = explode(config('consts.utils.COMMA'), $facilityArticle->display_small_facility_ids);
+
+        // 指定された記事データを取得
+        $facilityDetailArticleIds = array_merge($xlFacilityIds, $lFacilityIds, $mFacilityIds, $sxlFacilityIds);
+        $facilityDetailArticles = Article::getArticlesByArticleType(Article::FACILITY_DETAIL_ARTICLE_TYPE)
+            ->whereIn('id', $facilityDetailArticleIds)
+            ->get();
+
+        // 取得した記事データから指定のIDを抽出し、返却する。
+        return [
+            self::dripDetailArticlesByIds($facilityDetailArticles, $xlFacilityIds),
+            self::dripDetailArticlesByIds($facilityDetailArticles, $lFacilityIds),
+            self::dripDetailArticlesByIds($facilityDetailArticles, $mFacilityIds),
+            self::dripDetailArticlesByIds($facilityDetailArticles, $sxlFacilityIds),
+        ];
+    }
+
+
+
+    /**
+     * facilityDetailArticlesとして取得したcollectionからidsに含まれるものを抽出し、配列として返却する
+     * @param Collection $facilityDetailArticles
+     * @param Array $ids ["1","2",....]
+     * @return Array
+     */
+    private static function dripDetailArticlesByIds($facilityDetailArticles, $ids)
+    {
+        $result = [];
+        foreach ($ids as $id) {
+            $facilityDetailArticle = $facilityDetailArticles->first(function ($facilityDetailArticle) use ($id) {
+                return $facilityDetailArticle->id === intval($id);
+            });
+            if ($facilityDetailArticle) {
+                array_push($result, $facilityDetailArticle);
+            }
+        }
+        return $result;
+    }
+}

--- a/resources/views/pages/guide/facility/show.blade.php
+++ b/resources/views/pages/guide/facility/show.blade.php
@@ -1,5 +1,7 @@
 @extends('layouts.common')
 
+@section('breadcrumb', Breadcrumbs::render('guideFacilityShow', $facilityArticle))
+
 @section('main')
 <main class="layout-base__main-center">
     <div class="layout-base__inner">

--- a/resources/views/pages/guide/facility/show.blade.php
+++ b/resources/views/pages/guide/facility/show.blade.php
@@ -18,7 +18,6 @@
             </div>
         </div>
 
-        {{-- 特大＆大サイズ --}}
         @foreach ($displayExtraLargeArticles as $facilityDetailArticle)
             {{-- 特大サイズ --}}
             @include('partials.dynamic.guide.facility.large_block', [
@@ -29,7 +28,7 @@
 
         <?php $left = true; ?>
         @foreach ($displayLargeArticles as $facilityDetailArticle)
-        {{-- 大サイズ　左 --}}
+            {{-- 大サイズ --}}
             @include('partials.dynamic.guide.facility.large_block', [
                 'facilityDetailArticle' => $facilityDetailArticle,
                 'isLeft' => $left

--- a/resources/views/partials/dynamic/guide/facility/large_block.blade.php
+++ b/resources/views/partials/dynamic/guide/facility/large_block.blade.php
@@ -12,7 +12,8 @@ if(isset($isExtraLarge) && $isExtraLarge) {
     <div class="visual-block visual-block--{{ $class }}">
         <div class="visual-block__visual">
             <picture class="js-scroll animation-image-ratio">
-                <source srcset="/assets/images/_dummy-img01.png" media="(min-width: 768px)">
+                <source srcset="{{ imageUrlById($facilityDetailArticle->facility_image) }}" media="(min-width: 768px)">
+                {{-- TODO: SPとPCで表示する画像が違うが、これはどうするのか。確認する --}}
                 <source srcset="/assets/images/_dummy-img02.png" media="(max-width: 767px)">
                 <img class="visual-block__visual-image animation-image-ratio__img" src="{{ imageUrlById($facilityDetailArticle->facility_image) }}" alt="">
             </picture>

--- a/routes/breadcrumbs.php
+++ b/routes/breadcrumbs.php
@@ -19,6 +19,13 @@ Breadcrumbs::for('whatsNewShow', function ($trail, $infoArticle) {
     $trail->push($infoArticle->title, route('whats_new_show', ['key' => $infoArticle->permalink]));
 });
 
+// 施設案内
+Breadcrumbs::for('guideFacilityShow', function ($trail, $facilityArticle) {
+    $trail->parent('topPage');
+    $trail->push($facilityArticle->title, route('guide_facility_show', ['permalink' => $facilityArticle->permalink]));
+});
+
+
 // 教員一覧
 Breadcrumbs::for('teacherIndex', function ($trail) {
     $trail->parent('topPage');

--- a/routes/web.php
+++ b/routes/web.php
@@ -25,12 +25,10 @@ Route::prefix('guide')->group(function () {
 
     // 詳細（孫）
     Route::get('/detail/{permalink}', 'Guide\FacilityDetailController@show')
-        ->where('permalink', '.+')
         ->name('guide_facility_detail_show');
 
     // 施設案内 + 施設詳細
     Route::get('/{permalink}', 'Guide\FacilityController@show')
-        ->where('permalink', '.+')
         ->name('guide_facility_show');
 });
 


### PR DESCRIPTION
## 概要

- backend側で施設案内のデータ仕様が変わったため、それに対応
    - https://github.com/team-lab/tlb-cms-backend/pull/2528

## 内容

models側で設定された表示サイズごとに登録される施設詳細のidを取得し、それに合わせて記事を取得するようにした。